### PR TITLE
FIX: off by one error and misc in analog conversion

### DIFF
--- a/lcls2-cc-lib/Library/POUs/FB_AnalogToRaw.TcPOU
+++ b/lcls2-cc-lib/Library/POUs/FB_AnalogToRaw.TcPOU
@@ -16,15 +16,15 @@ VAR
 END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Converts a real unit value (e.g., volts) to the integer needed for an analog output terminal.
-IF fScale = 0 AND fMax <> fMin THEN
-	fScale := EXPT(2, iBits) / (fMax - fMin);
+IF fScale = 0 AND fMax > fMin THEN
+	fScale := (EXPT(2, iBits) - 1) / (fMax - fMin);
+END_IF
+IF fReal > fMax THEN
+	fReal := fMax;
+ELSIF fReal < fMin THEN
+	fReal := fMin;
 END_IF
 iRaw := LREAL_TO_INT((fReal - fMin) * fScale);]]></ST>
     </Implementation>
-    <LineIds Name="FB_AnalogToRaw">
-      <LineId Id="9" Count="0" />
-      <LineId Id="21" Count="2" />
-      <LineId Id="26" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>

--- a/lcls2-cc-lib/Library/POUs/FB_RawToAnalog.TcPOU
+++ b/lcls2-cc-lib/Library/POUs/FB_RawToAnalog.TcPOU
@@ -17,21 +17,12 @@ END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[// Converts the integer from an analog input terminal to a real unit value (e.g., volts)
-IF fScale = 0 AND fMax <> fMin THEN
-	fScale := EXPT(2, iBits) / (fMax - fMin);
+IF fScale = 0 AND fMax > fMin THEN
+	fScale := (EXPT(2, iBits) - 1) / (fMax - fMin);
 END_IF
 IF fScale <> 0 THEN
 	fReal := iRaw / fScale + fMin;
 END_IF]]></ST>
     </Implementation>
-    <LineIds Name="FB_RawToAnalog">
-      <LineId Id="9" Count="0" />
-      <LineId Id="17" Count="0" />
-      <LineId Id="20" Count="0" />
-      <LineId Id="19" Count="0" />
-      <LineId Id="35" Count="0" />
-      <LineId Id="21" Count="0" />
-      <LineId Id="36" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
Takes care of a funny bug where the PPM illuminator would turn off at 100% and also handles related edge cases. Basically, the integer was overflowing when we tried to set it to 2^15 since the max value is actually 2^15-1.