### PR TITLE
ENH: Add user lens lock and reorganize function block

### DIFF
--- a/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM.TcPOU
@@ -10,6 +10,18 @@ VAR_IN_OUT
     stEl6Out: EL6OutData22b;
 END_VAR
 VAR_INPUT
+    {attribute 'pytmc' := '
+        pv: CLZ:LOCK
+        io: io
+    '}
+    bZoomLock: BOOL;
+
+    {attribute 'pytmc' := '
+        pv: CLF:LOCK
+        io: io
+    '}
+    bFocusLock: BOOL;
+
     bZoomEndFwd AT %I*: BOOL;
     bZoomEndBwd AT %I*: BOOL;
     bFocusEndFwd AT %I*: BOOL;
@@ -48,37 +60,45 @@ VAR
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[fbYStage(stMotionStage:=stYStage);
-// All stages have no STO
+      <ST><![CDATA[// All stages have no STO, but there is a user lock on the lens
 stYStage.bHardwareEnable := TRUE;
-stZoomStage.bHardwareEnable := TRUE;
-stFocusStage.bHardwareEnable := TRUE;
+stZoomStage.bHardwareEnable := NOT bZoomLock;
+stFocusStage.bHardwareEnable := NOT bFocusLock;
+
 // No PMPS yet
 stYStage.bPowerSelf := TRUE;
 stZoomStage.bPowerSelf := TRUE;
 stFocusStage.bPowerSelf := TRUE;
+
 // No limit switch at the bottom
 stYStage.bLimitBackwardEnable := TRUE;
+
 // Lens limits are normally open
 stZoomStage.bLimitForwardEnable := NOT bZoomEndFwd;
 stZoomStage.bLimitBackwardEnable := NOT bZoomEndBwd;
 stFocusStage.bLimitForwardEnable := NOT bFocusEndFwd;
 stFocusStage.bLimitBackwardEnable := NOT bFocusEndBwd;
+
 // Home Lens to LLS
 stZoomStage.nHomingMode := ENUM_EpicsHomeCmd.LOW_LIMIT;
 stFocusStage.nHomingMode := ENUM_EpicsHomeCmd.LOW_LIMIT;
+
+fbYStage(stMotionStage:=stYStage);
+fbZoom(stMotionStage:=stZoomStage);
+fbFocus(stMotionStage:=stFocusStage);
+
 fbStates(
     stMotionStage:=stYStage,
     fYag:=fYag,
     fDiamond:=fDiamond,
     fReticle:=fReticle,
     fOut:=fOut);
-fbZoom(stMotionStage:=stZoomStage);
-fbFocus(stMotionStage:=stFocusStage);
+
 fbFilterWheel(
     bExecute:=TRUE,
     stIn_El6:=stEl6In,
     stOut_El6:=stEl6Out);
+
 fbOpal();
 fbFlowSwitch();]]></ST>
     </Implementation>


### PR DESCRIPTION
closes #27 

This relies on autosave for maintaining the lock state... I'm not sure if that's good enough.