### PR TITLE
ENH: Add XPIM LED auto-shutoff

### DIFF
--- a/lcls2-cc-lib/Library/Devices/PPM/FB_PPM_Gige.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/PPM/FB_PPM_Gige.TcPOU
@@ -7,8 +7,8 @@ VAR
 
     {attribute 'pytmc' := '
         pv: PWR
-        ZNAM: OFF
-        ONAM: ON
+        field: ZNAM OFF
+        field: ONAM ON
     '}
     bGigePower AT %Q*: BOOL;
 

--- a/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM.TcPOU
@@ -42,6 +42,11 @@ VAR
     fbOpal: FB_XPIM_Opal;
 
     {attribute 'pytmc' := '
+        pv: CIL
+    '}
+    fbLED: FB_XPIM_LED;
+
+    {attribute 'pytmc' := '
         pv: SFW
     '}
     fbFlowSwitch: FB_XTES_Flowswitch;
@@ -80,6 +85,7 @@ fbFilterWheel(
     stIn_El6:=stEl6In,
     stOut_El6:=stEl6Out);
 fbOpal();
+fbLED(enumXPIM:=fbStates.enumGet);
 fbFlowSwitch();]]></ST>
     </Implementation>
   </POU>

--- a/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_LED.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_LED.TcPOU
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_XPIM_LED" Id="{1459dd05-d653-484a-8cdf-74137bcaece7}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_XPIM_LED
+VAR_INPUT
+    {attribute 'pytmc' := '
+        pv: PWR
+        io: io
+        ZNAM: OFF
+        ONAM: ON
+    '}
+    bLEDPower AT %Q*: BOOL;
+
+    {attribute 'pytmc' := '
+        pv: AUTO
+        io: io
+    '}
+    bLEDAuto: BOOL := TRUE;
+
+    {attribute 'pytmc' := '
+        pv: CLK:TIMEOUT
+        io: io
+        field: EGU min
+    '}
+    fLEDTimeOut: LREAL := 60;
+
+    enumXPIM: ENUM_XPIM_States;
+END_VAR
+VAR_OUTPUT
+    {attribute 'pytmc' := '
+        pv: CLK:REMAINING
+        io: io
+        field: EGU min
+    '}
+    fLEDRemaining: LREAL;
+END_VAR
+VAR
+    tonLED: TON;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[// If configured, change the LED level automatically
+// LED is always (and only) useful at Reticle state
+IF bLEDAuto THEN
+    // Turn on the LED when we get to the Reticle
+    IF enumXPIM = ENUM_XPIM_States.Reticle THEN
+        bLEDPower := TRUE;
+    // Turn off the LED when we stop at any other state
+    ELSIF enumXPIM <> ENUM_XPIM_States.Unknown THEN
+        bLEDPower := FALSE;
+    END_IF
+END_IF
+
+// If configured, start a shutdown timer when LED goes high
+IF fLEDTimeOut <> 0 THEN;
+    tonLED(IN:=bLEDPower,
+           PT:=LREAL_TO_TIME(fLEDTimeOut * 60 * 1000));
+    fLEDRemaining := fLEDTimeOut - TIME_TO_LREAL(tonLED.ET) / 60 / 1000;
+
+    IF tonLED.Q THEN
+        bLEDPower := FALSE;
+    END_IF
+END_IF]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_LED.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_LED.TcPOU
@@ -6,8 +6,8 @@ VAR_INPUT
     {attribute 'pytmc' := '
         pv: PWR
         io: io
-        ZNAM: OFF
-        ONAM: ON
+        field: ZNAM OFF
+        field: ONAM ON
     '}
     bLEDPower AT %Q*: BOOL;
 

--- a/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_LED.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_LED.TcPOU
@@ -22,7 +22,7 @@ VAR_INPUT
         io: io
         field: EGU min
     '}
-    fLEDTimeOut: LREAL := 60;
+    fLEDTimeOut: LREAL := 10;
 
     enumXPIM: ENUM_XPIM_States;
 END_VAR

--- a/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_LED.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_LED.TcPOU
@@ -36,12 +36,13 @@ VAR_OUTPUT
 END_VAR
 VAR
     tonLED: TON;
+    enumLastCycle: ENUM_XPIM_States := ENUM_XPIM_States.Unknown;
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[// If configured, change the LED level automatically
 // LED is always (and only) useful at Reticle state
-IF bLEDAuto THEN
+IF bLEDAuto AND enumXPIM <> enumLastCycle THEN
     // Turn on the LED when we get to the Reticle
     IF enumXPIM = ENUM_XPIM_States.Reticle THEN
         bLEDPower := TRUE;
@@ -50,6 +51,7 @@ IF bLEDAuto THEN
         bLEDPower := FALSE;
     END_IF
 END_IF
+enumLastCycle := enumXPIM;
 
 // If configured, start a shutdown timer when LED goes high
 IF fLEDTimeOut <> 0 THEN;

--- a/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_Opal.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_Opal.TcPOU
@@ -6,8 +6,8 @@ VAR_INPUT
     {attribute 'pytmc' := '
         pv: PWR
         io: io
-        ZNAM: OFF
-        ONAM: ON
+        field: ZNAM OFF
+        field: ONAM ON
     '}
     bOpalPower AT %Q*: BOOL;
 END_VAR

--- a/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_Opal.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_Opal.TcPOU
@@ -2,7 +2,7 @@
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <POU Name="FB_XPIM_Opal" Id="{b1b890b6-3afe-4a18-b0c8-85c6c6d77f08}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_XPIM_Opal
-VAR
+VAR_INPUT
     {attribute 'pytmc' := '
         pv: PWR
         io: io
@@ -10,15 +10,9 @@ VAR
         ONAM: ON
     '}
     bOpalPower AT %Q*: BOOL;
+END_VAR
+VAR
     bOpalInit: BOOL := FALSE;
-
-    {attribute 'pytmc' := '
-        pv: CIL:PWR
-        io: io
-        ZNAM: OFF
-        ONAM: ON
-    '}
-    bLedPower AT %Q*: BOOL;
 END_VAR
 ]]></Declaration>
     <Implementation>

--- a/lcls2-cc-lib/Library/Library.plcproj
+++ b/lcls2-cc-lib/Library/Library.plcproj
@@ -73,6 +73,9 @@
     <Compile Include="Devices\XPIM\FB_XPIM_FilterWheel.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Devices\XPIM\FB_XPIM_LED.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Devices\XPIM\FB_XPIM_Opal.TcPOU">
       <SubType>Code</SubType>
     </Compile>

--- a/lcls2-cc-lib/Library/POUs/FB_XTES_Flowswitch.TcPOU
+++ b/lcls2-cc-lib/Library/POUs/FB_XTES_Flowswitch.TcPOU
@@ -5,8 +5,8 @@
 VAR_OUTPUT
     {attribute 'pytmc' := '
         pv: FLOW
-        ZNAM: LOW
-        ONAM: OK
+        field: ZNAM LOW
+        field: ONAM OK
     '}
     bFlowOk AT %I*: BOOL;
 END_VAR


### PR DESCRIPTION
closes #24 
closes #25 

refactors slightly since there's enough LED code to deserve its own FB

fixes some malformed pragmas since these existed in the same files

will require some io linkage pragma changes in the `lcls-plc-lfe-motion` and `lcls-plc-kfe-motion` libraries