### PR TITLE
MNT: remove placeholder resolution from dependencies

### DIFF
--- a/lcls2-cc-lib/Library/Library.plcproj
+++ b/lcls2-cc-lib/Library/Library.plcproj
@@ -153,17 +153,6 @@
       <Namespace>Tc2_Utilities</Namespace>
     </PlaceholderReference>
   </ItemGroup>
-  <ItemGroup>
-    <PlaceholderResolution Include="LCLS General">
-      <Resolution>LCLS General, * (SLAC)</Resolution>
-    </PlaceholderResolution>
-    <PlaceholderResolution Include="lcls-twincat-motion">
-      <Resolution>lcls-twincat-motion, * (SLAC)</Resolution>
-    </PlaceholderResolution>
-    <PlaceholderResolution Include="PMPS">
-      <Resolution>PMPS, * (SLAC - LCLS)</Resolution>
-    </PlaceholderResolution>
-  </ItemGroup>
   <ProjectExtensions>
     <PlcProjectOptions>
       <XmlArchive>


### PR DESCRIPTION
When the libraries are redirected with placeholder resolution, the built library can only be used with whatever the latest libraries were at the time of building. This creates a dependency/rebuilding headache where we'd need to rebuild the library every time any dependency updated. You may want this to protect yourself from API breaks but in this case it is a hassle.