### PR TITLE
MNT: force home position to zero for lens

### DIFF
--- a/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM.TcPOU
@@ -87,6 +87,7 @@ stZoomStage.bPowerSelf := TRUE;
 stZoomStage.bLimitForwardEnable := NOT bZoomEndFwd;
 stZoomStage.bLimitBackwardEnable := NOT bZoomEndBwd;
 stZoomStage.nHomingMode := ENUM_EpicsHomeCmd.LOW_LIMIT;
+stZoomStage.fHomePosition := 0;
 
 fbFocus(stMotionStage:=stFocusStage);
 stFocusStage.bHardwareEnable := NOT bFocusLock;
@@ -94,6 +95,7 @@ stFocusStage.bPowerSelf := TRUE;
 stFocusStage.bLimitForwardEnable := NOT bFocusEndFwd;
 stFocusStage.bLimitBackwardEnable := NOT bFocusEndBwd;
 stFocusStage.nHomingMode := ENUM_EpicsHomeCmd.LOW_LIMIT;
+stFocusStage.fHomePosition := 0;
 
 // Set special error message for lens lock
 IF stZoomStage.bExecute AND bZoomLock THEN


### PR DESCRIPTION
closes #52 

This already mostly works in prod actually, since I set the homing mode variable prior to it even working
I've noticed in testing that hitting HOMR/HOMF in the IOC can reset the home position variables to some other value, so here I'm just forcing it back to be the correct value: zero at the negative limit.