### PR TITLE
ENH: allow plc project to change state mover settings and safety adjustments for common components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,47 @@
 language: python
-os: linux
-dist: xenial
 python: 3.7
 
 env:
   global:
     # Doctr deploy key for pcdshub/lcls2-cc-lib
     - secure: "OeuTu/RP3lno2L0KkpPBH7vpSd+Uwzhb13iBVE2xoWkoiJMoNoWLiwr97hpehwcSwFEJ7OFN+aK7urh2+zgRcf3ZA+gCFDSlhshVKK3AUl9w4d2vXFP7aFgZcDFO0nea0CHN0id73ZKMluk0aSjmR7z5XDgT0EYAyeob0BVNV9onuRBHoYek6uPV0aSe0JWe5+IQ5i0e+YSWz9w0dT+oIgDo13+m9D4BQNxLL5TutbSbAQNoRDfcColA19EbE3OgaakTwiX7VEbte8b4vEVL7nOAE86s9ZiSiAKRq2CMYeaNoGmwQumJo/Ul6N/KBOYkyXjPlwvkqcs3IwGqdnauhg+a+7i72PgI2DO5/w+p8X//7jNHnNKp+JmW6FhTtOzkgGaOi0KC++c50OaXMZbrICY+YfbFjcrGrvAlgw+UzKrM6f9/3XnnE6dynAfe5sjYZXg2ivhx7jjNY3Segm4b4PeawHJTwo1VlH8yxF2jB4nHpFXlL3vrNarbRHBc48J653MKjE9ucVziHEkOJt1G58c+3R6WgG3t8iVu7RfYomQQ9LdS4YZuENeAS1h64+c56e10yl0j9p34ThfXgy+94lai7t20QmF4QuoDRWwuUayvDY3Fos3Z827WfIsOuO/BHZBV8nzq6Zqa0Z6+izHvqoc6j2GXexlw6ZFMib+VQIQ="
+    # If using a custom version of the CI helpers, change the following in
+    # addition to the `import` block elow:
+    # - CI_HELPER_URL=https://github.com/klauer/pcds-ci-helpers
+    # - CI_HELPER_BRANCH=twincat_shared_configs
 
-jobs:
-  include:
-    - name: Project summary
-      env: TWINCAT_SUMMARY=1
-    - name: Pragma linting
-      env: TWINCAT_PRAGMALINT=1
-    - name: Documentation building
-      env: TWINCAT_BUILD_DOCS=1
-    - name: Twincat Style
-      env: TWINCAT_STYLE=1
-    - name: Pre-commit Checks
-      env: PRE_COMMIT=1
+# Uncomment this block if you would like to make a test an allowed failure
+#jobs:
+#  allow_failures:
+#    - name: "Style Check"
+#    - name: "Pre-commit Checks"
 
-install:
-  # Import the helper scripts
-  - git clone --depth 1 git://github.com/pcdshub/pcds-ci-helpers.git
-  # Start the helper-script initialization + run based on environment variables
-  - source pcds-ci-helpers/travis/init.sh
+import:
+  - pcdshub/pcds-ci-helpers:travis/shared_configs/twincat/standard.yml
+
+# If not using the standard-python-conda above please uncomment the required
+# (language, os, dist and stages) and optional (import statements) entries from
+# the blocks below.
+#
+#language: python
+#os: linux
+#dist: xenial
+#
+#stages:
+#  - build
+#  - test
+#  - name: deploy
+#    if: (branch = master OR tag IS present) AND type != pull_request
+#
+#import:
+#  # Build stage
+#  - pcdshub/pcds-ci-helpers:travis/shared_configs/twincat/setup.yml
+#  # Test stage
+#  - pcdshub/pcds-ci-helpers:travis/shared_configs/twincat/docs-build.yml
+#  - pcdshub/pcds-ci-helpers:travis/shared_configs/twincat/pragmalint.yml
+#  - pcdshub/pcds-ci-helpers:travis/shared_configs/twincat/pre-commit.yml
+#  - pcdshub/pcds-ci-helpers:travis/shared_configs/twincat/style.yml
+#  - pcdshub/pcds-ci-helpers:travis/shared_configs/twincat/summary.yml
+#  # Deploy stage
+#  - pcdshub/pcds-ci-helpers:travis/shared_configs/twincat/doctr-upload.yml
+

--- a/lcls2-cc-lib/Library/Devices/ATM/FB_ATM_States.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/ATM/FB_ATM_States.TcPOU
@@ -26,13 +26,14 @@ VAR_OUTPUT
     enumGet: ENUM_ATM_States;
 END_VAR
 VAR
+    fbStateDefaults: FB_PositionState_Defaults;
     bATMInit: BOOL;
 END_VAR
 VAR CONSTANT
     fInDelta: LREAL := 2;
     fOutDelta: LREAL := 2;
-    fInVelocity: LREAL := 5;
-    fOutVelocity: LREAL := 5;
+    fInVelocity: LREAL := 1;
+    fOutVelocity: LREAL := 1;
     fAccel: LREAL := 200;
     fOutDecel: LREAL := 25;
 END_VAR
@@ -42,45 +43,63 @@ END_VAR
     bATMInit := TRUE;
 
     stOut.sName := 'OUT';
-    stOut.fVelocity := fOutVelocity;
-    stOut.fDelta := fOutDelta;
-    stOut.fAccel := fAccel;
-    stOut.fDecel := fOutDecel;
+    fbStateDefaults(
+        stPositionState:=stOut,
+        fVeloDefault:=fOutVelocity,
+        fDeltaDefault:=fOutDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fOutDecel,
+    );
     stOut.bMoveOk := TRUE;
 
     stTarget1.sName := 'TARGET1';
-    stTarget1.fVelocity := fInVelocity;
-    stTarget1.fDelta := fInDelta;
-    stTarget1.fAccel := fAccel;
-    stTarget1.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stTarget1,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stTarget1.bMoveOk := TRUE;
 
     stTarget2.sName := 'TARGET2';
-    stTarget2.fVelocity := fInVelocity;
-    stTarget2.fDelta := fInDelta;
-    stTarget2.fAccel := fAccel;
-    stTarget2.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stTarget2,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stTarget2.bMoveOk := TRUE;
 
     stTarget3.sName := 'TARGET3';
-    stTarget3.fVelocity := fInVelocity;
-    stTarget3.fDelta := fInDelta;
-    stTarget3.fAccel := fAccel;
-    stTarget3.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stTarget3,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stTarget3.bMoveOk := TRUE;
 
     stTarget4.sName := 'TARGET4';
-    stTarget4.fVelocity := fInVelocity;
-    stTarget4.fDelta := fInDelta;
-    stTarget4.fAccel := fAccel;
-    stTarget4.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stTarget4,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stTarget4.bMoveOk := TRUE;
 
     stTarget5.sName := 'TARGET5';
-    stTarget5.fVelocity := fInVelocity;
-    stTarget5.fDelta := fInDelta;
-    stTarget5.fAccel := fAccel;
-    stTarget5.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stTarget5,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stTarget5.bMoveOk := TRUE;
 
     arrStates[1] := stOut;

--- a/lcls2-cc-lib/Library/Devices/LIC/FB_LIC_States.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/LIC/FB_LIC_States.TcPOU
@@ -24,13 +24,14 @@ VAR_OUTPUT
     enumGet: ENUM_LIC_States;
 END_VAR
 VAR
+    fbStateDefaults: FB_PositionState_Defaults;
     bLICInit: BOOL;
 END_VAR
 VAR CONSTANT
     fInDelta: LREAL := 2;
     fOutDelta: LREAL := 2;
-    fInVelocity: LREAL := 5;
-    fOutVelocity: LREAL := 5;
+    fInVelocity: LREAL := 1;
+    fOutVelocity: LREAL := 1;
     fAccel: LREAL := 200;
     fOutDecel: LREAL := 25;
 END_VAR
@@ -40,31 +41,43 @@ END_VAR
     bLICInit := TRUE;
 
     stOut.sName := 'OUT';
-    stOut.fVelocity := fOutVelocity;
-    stOut.fDelta := fOutDelta;
-    stOut.fAccel := fAccel;
-    stOut.fDecel := fOutDecel;
+    fbStateDefaults(
+        stPositionState:=stOut,
+        fVeloDefault:=fOutVelocity,
+        fDeltaDefault:=fOutDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fOutDecel,
+    );
     stOut.bMoveOk := TRUE;
 
     stMirror1.sName := 'MIRROR1';
-    stMirror1.fVelocity := fInVelocity;
-    stMirror1.fDelta := fInDelta;
-    stMirror1.fAccel := fAccel;
-    stMirror1.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stMirror1,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stMirror1.bMoveOk := TRUE;
 
     stMirror2.sName := 'MIRROR2';
-    stMirror2.fVelocity := fInVelocity;
-    stMirror2.fDelta := fInDelta;
-    stMirror2.fAccel := fAccel;
-    stMirror2.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stMirror2,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stMirror2.bMoveOk := TRUE;
 
     stTarget1.sName := 'TARGET';
-    stTarget1.fVelocity := fInVelocity;
-    stTarget1.fDelta := fInDelta;
-    stTarget1.fAccel := fAccel;
-    stTarget1.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stTarget1,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stTarget1.bMoveOk := TRUE;
 
     arrStates[1] := stOut;

--- a/lcls2-cc-lib/Library/Devices/PPM/FB_PPM_States.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/PPM/FB_PPM_States.TcPOU
@@ -24,6 +24,7 @@ VAR_OUTPUT
     enumGet: ENUM_PPM_States;
 END_VAR
 VAR
+    fbStateDefaults: FB_PositionState_Defaults;
     bPPMInit: BOOL;
 END_VAR
 VAR CONSTANT
@@ -42,63 +43,43 @@ END_VAR
     bPPMInit := TRUE;
 
     stOut.sName := 'OUT';
-    IF stOut.fVelocity = 0 THEN
-        stOut.fVelocity := fOutVelocity;
-	END_IF
-    IF stOut.fDelta = 0 THEN
-        stOut.fDelta := fOutDelta;
-	END_IF
-    IF stOut.fAccel = 0 THEN
-        stOut.fAccel := fAccel;
-	END_IF
-    IF stOut.fDecel = 0 THEN
-        stOut.fDecel := fOutDecel;
-	END_IF
+    fbStateDefaults(
+        stPositionState:=stOut,
+        fVeloDefault:=fOutVelocity,
+        fDeltaDefault:=fOutDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fOutDecel,
+    );
     stOut.bMoveOk := TRUE;
 
     stPower.sName := 'POWERMETER';
-    IF stPower.fVelocity = 0 THEN
-        stPower.fVelocity := fInVelocity;
-	END_IF
-    IF stPower.fDelta = 0 THEN
-        stPower.fDelta := fInDelta;
-	END_IF
-    IF stPower.fAccel = 0 THEN
-        stPower.fAccel := fAccel;        
-	END_IF
-    IF stPower.fDecel = 0 THEN
-        stPower.fDecel := fAccel;        
-	END_IF
+    fbStateDefaults(
+        stPositionState:=stPower,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stPower.bMoveOk := TRUE;
 
     stYag1.sName := 'YAG1';
-    IF stYag1.fVelocity = 0 THEN
-        stYag1.fVelocity := fInVelocity;
-	END_IF
-    IF stYag1.fDelta = 0 THEN
-        stYag1.fDelta := fInDelta;
-	END_IF
-    IF stYag1.fAccel = 0 THEN
-        stYag1.fAccel := fAccel;
-	END_IF
-    IF stYag1.fDecel = 0 THEN
-        stYag1.fDecel := fAccel;
-	END_IF
+    fbStateDefaults(
+        stPositionState:=stYag1,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stYag1.bMoveOk := TRUE;
 
     stYag2.sName := 'YAG2';
-    IF stYag2.fVelocity = 0 THEN
-        stYag2.fVelocity := fInVelocity;
-	END_IF
-    IF stYag2.fDelta = 0 THEN
-        stYag2.fDelta := fInDelta;
-	END_IF
-    IF stYag2.fAccel = 0 THEN
-        stYag2.fAccel := fAccel;
-	END_IF
-    IF stYag2.fDecel = 0 THEN
-        stYag2.fDecel := fAccel;
-	END_IF
+    fbStateDefaults(
+        stPositionState:=stYag2,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stYag2.bMoveOk := TRUE;
 
     arrStates[1] := stOut;

--- a/lcls2-cc-lib/Library/Devices/PPM/FB_PPM_States.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/PPM/FB_PPM_States.TcPOU
@@ -29,8 +29,8 @@ END_VAR
 VAR CONSTANT
     fInDelta: LREAL := 2;
     fOutDelta: LREAL := 2;
-    fInVelocity: LREAL := 5;
-    fOutVelocity: LREAL := 5;
+    fInVelocity: LREAL := 1;
+    fOutVelocity: LREAL := 1;
     fAccel: LREAL := 200;
     fOutDecel: LREAL := 25;
 END_VAR

--- a/lcls2-cc-lib/Library/Devices/PPM/FB_PPM_States.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/PPM/FB_PPM_States.TcPOU
@@ -27,6 +27,8 @@ VAR
     bPPMInit: BOOL;
 END_VAR
 VAR CONSTANT
+    // These are the default values
+    // Set values on states prior to passing in for non-default values
     fInDelta: LREAL := 2;
     fOutDelta: LREAL := 2;
     fInVelocity: LREAL := 1;
@@ -40,31 +42,63 @@ END_VAR
     bPPMInit := TRUE;
 
     stOut.sName := 'OUT';
-    stOut.fVelocity := fOutVelocity;
-    stOut.fDelta := fOutDelta;
-    stOut.fAccel := fAccel;
-    stOut.fDecel := fOutDecel;
+    IF stOut.fVelocity = 0 THEN
+        stOut.fVelocity := fOutVelocity;
+	END_IF
+    IF stOut.fDelta = 0 THEN
+        stOut.fDelta := fOutDelta;
+	END_IF
+    IF stOut.fAccel = 0 THEN
+        stOut.fAccel := fAccel;
+	END_IF
+    IF stOut.fDecel = 0 THEN
+        stOut.fDecel := fOutDecel;
+	END_IF
     stOut.bMoveOk := TRUE;
 
     stPower.sName := 'POWERMETER';
-    stPower.fVelocity := fInVelocity;
-    stPower.fDelta := fInDelta;
-    stPower.fAccel := fAccel;
-    stPower.fDecel := fAccel;
+    IF stPower.fVelocity = 0 THEN
+        stPower.fVelocity := fInVelocity;
+	END_IF
+    IF stPower.fDelta = 0 THEN
+        stPower.fDelta := fInDelta;
+	END_IF
+    IF stPower.fAccel = 0 THEN
+        stPower.fAccel := fAccel;        
+	END_IF
+    IF stPower.fDecel = 0 THEN
+        stPower.fDecel := fAccel;        
+	END_IF
     stPower.bMoveOk := TRUE;
 
     stYag1.sName := 'YAG1';
-    stYag1.fVelocity := fInVelocity;
-    stYag1.fDelta := fInDelta;
-    stYag1.fAccel := fAccel;
-    stYag1.fDecel := fAccel;
+    IF stYag1.fVelocity = 0 THEN
+        stYag1.fVelocity := fInVelocity;
+	END_IF
+    IF stYag1.fDelta = 0 THEN
+        stYag1.fDelta := fInDelta;
+	END_IF
+    IF stYag1.fAccel = 0 THEN
+        stYag1.fAccel := fAccel;
+	END_IF
+    IF stYag1.fDecel = 0 THEN
+        stYag1.fDecel := fAccel;
+	END_IF
     stYag1.bMoveOk := TRUE;
 
     stYag2.sName := 'YAG2';
-    stYag2.fVelocity := fInVelocity;
-    stYag2.fDelta := fInDelta;
-    stYag2.fAccel := fAccel;
-    stYag2.fDecel := fAccel;
+    IF stYag2.fVelocity = 0 THEN
+        stYag2.fVelocity := fInVelocity;
+	END_IF
+    IF stYag2.fDelta = 0 THEN
+        stYag2.fDelta := fInDelta;
+	END_IF
+    IF stYag2.fAccel = 0 THEN
+        stYag2.fAccel := fAccel;
+	END_IF
+    IF stYag2.fDecel = 0 THEN
+        stYag2.fDecel := fAccel;
+	END_IF
     stYag2.bMoveOk := TRUE;
 
     arrStates[1] := stOut;

--- a/lcls2-cc-lib/Library/Devices/WFS/FB_WFS_States.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/WFS/FB_WFS_States.TcPOU
@@ -26,13 +26,14 @@ VAR_OUTPUT
     enumGet: ENUM_WFS_States;
 END_VAR
 VAR
+    fbStateDefaults: FB_PositionState_Defaults;
     bWFSInit: BOOL;
 END_VAR
 VAR CONSTANT
     fInDelta: LREAL := 2;
     fOutDelta: LREAL := 2;
-    fInVelocity: LREAL := 5;
-    fOutVelocity: LREAL := 5;
+    fInVelocity: LREAL := 1;
+    fOutVelocity: LREAL := 1;
     fAccel: LREAL := 200;
     fOutDecel: LREAL := 25;
 END_VAR
@@ -42,45 +43,63 @@ END_VAR
     bWFSInit := TRUE;
 
     stOut.sName := 'OUT';
-    stOut.fVelocity := fOutVelocity;
-    stOut.fDelta := fOutDelta;
-    stOut.fAccel := fAccel;
-    stOut.fDecel := fOutDecel;
+    fbStateDefaults(
+        stPositionState:=stOut,
+        fVeloDefault:=fOutVelocity,
+        fDeltaDefault:=fOutDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fOutDecel,
+    );
     stOut.bMoveOk := TRUE;
 
     stTarget1.sName := 'TARGET1';
-    stTarget1.fVelocity := fInVelocity;
-    stTarget1.fDelta := fInDelta;
-    stTarget1.fAccel := fAccel;
-    stTarget1.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stTarget1,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stTarget1.bMoveOk := TRUE;
 
     stTarget2.sName := 'TARGET2';
-    stTarget2.fVelocity := fInVelocity;
-    stTarget2.fDelta := fInDelta;
-    stTarget2.fAccel := fAccel;
-    stTarget2.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stTarget2,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stTarget2.bMoveOk := TRUE;
 
     stTarget3.sName := 'TARGET3';
-    stTarget3.fVelocity := fInVelocity;
-    stTarget3.fDelta := fInDelta;
-    stTarget3.fAccel := fAccel;
-    stTarget3.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stTarget3,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stTarget3.bMoveOk := TRUE;
 
     stTarget4.sName := 'TARGET4';
-    stTarget4.fVelocity := fInVelocity;
-    stTarget4.fDelta := fInDelta;
-    stTarget4.fAccel := fAccel;
-    stTarget4.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stTarget4,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stTarget4.bMoveOk := TRUE;
 
     stTarget5.sName := 'TARGET5';
-    stTarget5.fVelocity := fInVelocity;
-    stTarget5.fDelta := fInDelta;
-    stTarget5.fAccel := fAccel;
-    stTarget5.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stTarget5,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stTarget5.bMoveOk := TRUE;
 
     arrStates[1] := stOut;

--- a/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_States.TcPOU
+++ b/lcls2-cc-lib/Library/Devices/XPIM/FB_XPIM_States.TcPOU
@@ -24,13 +24,14 @@ VAR_OUTPUT
     enumGet: ENUM_XPIM_States;
 END_VAR
 VAR
+    fbStateDefaults: FB_PositionState_Defaults;
     bXPIMInit: BOOL;
 END_VAR
 VAR CONSTANT
     fInDelta: LREAL := 2;
     fOutDelta: LREAL := 2;
-    fInVelocity: LREAL := 5;
-    fOutVelocity: LREAL := 5;
+    fInVelocity: LREAL := 1;
+    fOutVelocity: LREAL := 1;
     fAccel: LREAL := 200;
     fOutDecel: LREAL := 25;
 END_VAR
@@ -40,31 +41,43 @@ END_VAR
     bXPIMInit := TRUE;
 
     stOut.sName := 'OUT';
-    stOut.fVelocity := fOutVelocity;
-    stOut.fDelta := fOutDelta;
-    stOut.fAccel := fAccel;
-    stOut.fDecel := fOutDecel;
+    fbStateDefaults(
+        stPositionState:=stOut,
+        fVeloDefault:=fOutVelocity,
+        fDeltaDefault:=fOutDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fOutDecel,
+    );
     stOut.bMoveOk := TRUE;
 
     stYag.sName := 'YAG';
-    stYag.fVelocity := fInVelocity;
-    stYag.fDelta := fInDelta;
-    stYag.fAccel := fAccel;
-    stYag.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stYag,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stYag.bMoveOk := TRUE;
 
     stDiamond.sName := 'DIAMOND';
-    stDiamond.fVelocity := fInVelocity;
-    stDiamond.fDelta := fInDelta;
-    stDiamond.fAccel := fAccel;
-    stDiamond.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stDiamond,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stDiamond.bMoveOk := TRUE;
 
     stReticle.sName := 'RETICLE';
-    stReticle.fVelocity := fInVelocity;
-    stReticle.fDelta := fInDelta;
-    stReticle.fAccel := fAccel;
-    stReticle.fDecel := fAccel;
+    fbStateDefaults(
+        stPositionState:=stReticle,
+        fVeloDefault:=fInVelocity,
+        fDeltaDefault:=fInDelta,
+        fAccelDefault:=fAccel,
+        fDecelDefault:=fAccel,
+    );
     stReticle.bMoveOk := TRUE;
 
     arrStates[1] := stOut;

--- a/lcls2-cc-lib/Library/Library.plcproj
+++ b/lcls2-cc-lib/Library/Library.plcproj
@@ -118,6 +118,9 @@
     <Compile Include="POUs\FB_XTES_Flowswitch.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="POUs\FB_PositionState_Defaults.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="Version\Global_Version.TcGVL">
       <SubType>Code</SubType>
     </Compile>

--- a/lcls2-cc-lib/Library/POUs/FB_PositionState_Defaults.TcPOU
+++ b/lcls2-cc-lib/Library/POUs/FB_PositionState_Defaults.TcPOU
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="FB_PositionState_Defaults" Id="{5f326ffa-3869-4f51-b9bc-bdf476cd3f65}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_PositionState_Defaults
+VAR_IN_OUT
+    stPositionState: DUT_PositionState;
+END_VAR
+VAR_INPUT
+    fVeloDefault: LREAL;
+    fDeltaDefault: LREAL;
+    fAccelDefault: LREAL;
+    fDecelDefault: LREAL;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[IF stPositionState.fVelocity = 0 THEN
+    stPositionState.fVelocity := fVeloDefault;
+END_IF
+IF stPositionState.fDelta = 0 THEN
+    stPositionState.fDelta := fDeltaDefault;
+END_IF
+IF stPositionState.fAccel = 0 THEN
+    stPositionState.fAccel := fAccelDefault;
+END_IF
+IF stPositionState.fDecel = 0 THEN
+    stPositionState.fDecel := fDecelDefault;
+END_IF]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>


### PR DESCRIPTION
- Decrease default state move speed from 5mm/s to 1mm/s because 1mm/s is all but guaranteed to be a safe velocity, while 5mm/s crashes the IM4K4 turbo pump.
- Allow plc projects to set their state velocity, delta, acceleration, and deceleration by modifying the position state data structures as appropriate. Without this change, the state velocity will always revert to default on boot unless autosaved/restored properly, and similarly there's no easy to way to adjust the other settings.
- Fix the CI hopefully

I created this PR because the state velocities on the IM4K4 state mover reset to an unsafe value of 5mm/s and crashed a turbo again, and I noticed that there is no way to fix this without updating the common component library.